### PR TITLE
npm 3 support

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,13 +51,9 @@ var flatPath = path.join(process.cwd(), 'node_modules', 'traceur', 'bin', 'trace
 
 fs.lstat(nestedPath, function(err, stats) {
     if (!err && stats.isDirectory()) {
-        TraceurCompiler.prototype.include = [
-		nestedPath
-	];
+        TraceurCompiler.prototype.include = [nestedPath];
     } else {
-        TraceurCompiler.prototype.include = [
-		flatPath
-	];
+        TraceurCompiler.prototype.include = [flatPath];
     }
 });
 

--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ TraceurCompiler.prototype.compile = function(data, path, callback) {
 };
 
 var nestedPath = path.join(__dirname, 'node_modules', 'traceur', 'bin', 'traceur-runtime.js');
-var flatPath = path.join(__dirname, '..', 'traceur', 'bin', 'traceur-runtime.js');
+var flatPath = path.join(process.cwd(), 'node_modules', 'traceur', 'bin', 'traceur-runtime.js');
 
 fs.lstat(nestedPath, function(err, stats) {
     if (!err && stats.isDirectory()) {

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
-var traceurAPI = require('traceur/src/node/api.js'),
-	path = require('path');
+var traceurAPI = require('traceur/src/node/api.js');
+var path = require('path');
+var fs = require('fs');
 
 function TraceurCompiler(config) {
 	this.shouldCompile = /^app/;
@@ -45,8 +46,19 @@ TraceurCompiler.prototype.compile = function(data, path, callback) {
 	});
 };
 
-TraceurCompiler.prototype.include = [
-	path.join(__dirname, 'node_modules', 'traceur', 'bin', 'traceur-runtime.js')
-];
+var nestedPath = path.join(__dirname, 'node_modules', 'traceur', 'bin', 'traceur-runtime.js');
+var flatPath = path.join(__dirname, '..', 'traceur', 'bin', 'traceur-runtime.js');
+
+fs.lstat(nestedPath, function(err, stats) {
+    if (!err && stats.isDirectory()) {
+        TraceurCompiler.prototype.include = [
+		nestedPath
+	];
+    } else {
+        TraceurCompiler.prototype.include = [
+		flatPath
+	];
+    }
+});
 
 module.exports = TraceurCompiler;


### PR DESCRIPTION
tests for nested `node_modules/`, if that fails attempts to load traceur through a flat dependency tree model.

caveats: assumes that `process.cwd()` is the containing folder for the project's top-level `node_modules/`.
